### PR TITLE
Increase width and center-align PersonalHighScoreLabel

### DIFF
--- a/TikTovenaar/Leaderboardscreen.xaml
+++ b/TikTovenaar/Leaderboardscreen.xaml
@@ -81,7 +81,7 @@
                 </Style>
             </DataGrid.Resources>
         </DataGrid>
-        <Label x:Name="PersonalHighScoreLabel" Content="{Binding PersonalHighScore}" Foreground="White" HorizontalAlignment="Center" Margin="0,500,0,0" VerticalAlignment="Center" Width="364" FontSize="30"/>
+        <Label x:Name="PersonalHighScoreLabel" Content="{Binding PersonalHighScore}" Foreground="White" HorizontalAlignment="Center" Margin="0,500,0,0" VerticalAlignment="Center" Width="800" FontSize="30" HorizontalContentAlignment="Center"/>
         <Button Content="Terug" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,50" Click="ReturnButton_Click" Width="300" Height="40"
                 Background="#0D1117" Foreground= "#F0F0F0" FontWeight="Bold" BorderBrush="#FF0D1117" />
     </Grid>


### PR DESCRIPTION
The `Label` element with the name `PersonalHighScoreLabel` in the `Leaderboardscreen.xaml` file has been modified. The `Width` property of the label has been increased from `364` to `800`, and a new property `HorizontalContentAlignment="Center"` has been added to center-align the content horizontally within the label.